### PR TITLE
extern "C"

### DIFF
--- a/src/editline/readline.h
+++ b/src/editline/readline.h
@@ -39,6 +39,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _READLINE_H_
 #define _READLINE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <windows.h>
 
 /*

--- a/src/editline/wineditline.h
+++ b/src/editline/wineditline.h
@@ -39,6 +39,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _WINEDITLINE_H_
 #define _WINEDITLINE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <windows.h>
 
 /*


### PR DESCRIPTION
These files end with
```
#ifdef __cplusplus
}
#endif
```

but lack the corresponding

```
#ifdef __cplusplus
extern "C" {
#endif
```

which we've had to add in order to get wineditline working with a C/C++ project.